### PR TITLE
Fix(#2): Pretendard-Regular CDN 오류로 NanumSquareNeo 폰트로 대체

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -128,22 +128,14 @@ table {
 }
 
 @font-face {
-  font-family: "TAEBAEKmilkyway";
-  src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2302@1.0/TAEBAEKmilkyway.woff2")
-    format("woff2");
-  font-weight: 900;
-  font-style: normal;
-}
-@font-face {
-  font-family: "Pretendard-Regular";
-  src: url("https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff")
-    format("woff");
+  font-family: "NanumSquareNeo";
+  src: url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-bRg.eot);
   font-weight: 400;
-  font-style: normal;
+  font-display: swap;
 }
 
 * {
-  font-family: "Pretendard-Regular" !important;
+  font-family: "NanumSquareNeo" !important;
 }
 
 @keyframes slideDown {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated global typography to NanumSquareNeo for a refreshed, consistent look across the app.
  - Enabled font-display: swap to reduce perceived text loading delays.
  - Replaced previous default fonts to align with the new typeface.

- Chores
  - Removed deprecated font assets and references (e.g., Pretendard, TAEBAEKmilkyway) to streamline styling and reduce maintenance overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->