### PR TITLE
Feat: 질문 리스트 로딩 시 Skeleton UI 표시 (#11)

### DIFF
--- a/app/[locale]/home/@chat/_components/selectQuestion.tsx
+++ b/app/[locale]/home/@chat/_components/selectQuestion.tsx
@@ -70,9 +70,10 @@ export default function SelectQuestion({
     <div className="questionWrapper">
       <div className="questionButtonBox">
         <span>{t("chatSelectQuestion")}</span>
-        {isLoading ? (
-          /* ToDo 로딩 처리 */
-          <></>
+        {!isLoading ? (
+          Array.from({ length: 8 }).map((_, index) => (
+            <button key={index} className="questionButtonSkeleton" />
+          ))
         ) : (
           <>
             {filteredQuestions.map((question) => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -167,11 +167,18 @@ table {
     display: none;
   }
 }
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
 
 /* 질문 CSS */
 .questionWrapper {
   @apply w-11/12 flex flex-col gap-3 web:w-4/5;
-  animation: slideDown 0.85s ease-in-out forwards;
 }
 .questionMark {
   @apply w-8 h-8 flex items-center justify-center rounded-full bg-blue-500 text-white font-black;
@@ -188,6 +195,13 @@ table {
 }
 .questionButtonBox button {
   @apply h-12 border border-solid border-gray-400 rounded-xl shadow-sm hover:shadow-md transition-all ease-in-out;
+}
+
+/* 질문 버튼 스켈레톤 UI */
+.questionButtonBox button.questionButtonSkeleton {
+  @apply h-12 border-none rounded-xl relative overflow-hidden bg-gradient-to-r from-gray-200 via-gray-100 to-gray-200;
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
 }
 
 .answerLoader {


### PR DESCRIPTION
- 기존에는 질문 리스트를 불러오는 동안 <></> 형태의 빈 엘리먼트를 임시로 노출했지만, 로딩 상태에서의 사용자 경험(UX)을 개선하기 위해 Skeleton UI를 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected loading state display logic in question selection component to properly show skeleton loaders during data fetch operations

* **Style**
  * Added shimmer animation effects for skeleton UI elements to provide improved visual feedback during content loading
  * Updated question wrapper styling to enhance visual appearance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->