### PR TITLE
Refactor: 기본 locale prefix 제거로 SEO 최적화

### DIFF
--- a/app/[locale]/home/layout.tsx
+++ b/app/[locale]/home/layout.tsx
@@ -55,16 +55,19 @@ export async function generateMetadata({
       "TypeScript",
     ],
     alternates: {
-      canonical: `/${locale}/home`,
+      canonical: locale === LOCALE_KO ? "/home" : `/${locale}/home`,
       languages: {
-        ko: "/ko/home",
+        ko: "/home",
         en: "/en/home",
       },
     },
     openGraph: {
       title: config.title,
       description: config.description,
-      url: `${SITE_URL}/${locale}/home`,
+      url:
+        locale === LOCALE_KO
+          ? `${SITE_URL}/home`
+          : `${SITE_URL}/${locale}/home`,
       siteName: config.title,
       locale: locale === LOCALE_KO ? "ko_KR" : "en_US",
       type: "website",
@@ -118,7 +121,10 @@ export default async function MainLayout({
     alternateName: "Sungjun Um",
     jobTitle: locale === LOCALE_KO ? "프론트엔드 개발자" : "Frontend Developer",
     description: METADATA_CONFIG[locale].description,
-    url: `${SITE_URL}/${locale}/home`,
+    url:
+      locale === LOCALE_KO
+        ? `${SITE_URL}/home`
+        : `${SITE_URL}/${locale}/home`,
     image: `${SITE_URL}${METADATA_CONFIG[locale].ogImage}`,
     sameAs: [
       "https://github.com/umsungjun",

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -5,13 +5,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   return [
     {
-      url: `${baseUrl}/ko/home`,
+      url: `${baseUrl}/home`,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 1,
       alternates: {
         languages: {
-          ko: `${baseUrl}/ko/home`,
+          ko: `${baseUrl}/home`,
           en: `${baseUrl}/en/home`,
         },
       },
@@ -20,10 +20,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
       url: `${baseUrl}/en/home`,
       lastModified: new Date(),
       changeFrequency: "weekly",
-      priority: 1,
+      priority: 0.9,
       alternates: {
         languages: {
-          ko: `${baseUrl}/ko/home`,
+          ko: `${baseUrl}/home`,
           en: `${baseUrl}/en/home`,
         },
       },

--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -9,7 +9,7 @@ export const routing = defineRouting({
   /* 기본 언어 설정 */
   defaultLocale: LOCALE_KO,
   /* 언어별 경로 설정 */
-  localePrefix: "always",
+  localePrefix: "as-needed",
 });
 
 /* export const { Link, redirect, usePathname, useRouter } = createNavigation(routing); 코드는 Next.js의 Link, redirect, usePathname, useRouter를 사용할 수 있도록 래핑한 것입니다. 이를 사용하여 기존 next j에서 제공하는 API를 대체할 수 있습니다. */

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,30 +2,21 @@ import createMiddleware from "next-intl/middleware";
 import { NextRequest, NextResponse } from "next/server";
 
 import { routing } from "./i18n/routing";
-import { LOCALE_EN, LOCALE_KO } from "./lib/client/constants";
+import { LOCALE_EN } from "./lib/client/constants";
 
 const intlMiddleware = createMiddleware(routing);
 
 export default async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
-  // 루트 경로나 locale만 있는 경우 /home으로 리다이렉트
-  if (
-    pathname === "/" ||
-    pathname === `/${LOCALE_KO}` ||
-    pathname === `/${LOCALE_EN}`
-  ) {
-    // locale 추출
-    let locale = LOCALE_KO;
-    if (pathname === `/${LOCALE_EN}`) {
-      locale = LOCALE_EN;
-    } else if (pathname === `/${LOCALE_KO}`) {
-      locale = LOCALE_KO;
-    }
+  // 루트 경로 → /home으로 리다이렉트 (기본 locale은 prefix 없이)
+  if (pathname === "/") {
+    return NextResponse.redirect(new URL("/home", request.url));
+  }
 
-    // 직접 리다이렉트 반환
-    const url = new URL(`/${locale}/home`, request.url);
-    return NextResponse.redirect(url);
+  // /en만 접속한 경우 → /en/home으로 리다이렉트
+  if (pathname === `/${LOCALE_EN}`) {
+    return NextResponse.redirect(new URL(`/${LOCALE_EN}/home`, request.url));
   }
 
   // 나머지는 next-intl middleware에게 위임


### PR DESCRIPTION
- localePrefix를 always에서 as-needed로 변경하여 한국어 URL에서 /ko/ 제거
- middleware 리다이렉트 간소화 (/ → /home)
- 메타데이터, sitemap URL을 /ko/home에서 /home으로 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* 한국어 로케일의 URL 경로 구조를 최적화하여 검색 엔진 인덱싱 및 접근성 개선
* 다국어 지원을 위한 SEO 메타데이터 및 사이트맵 구조 업데이트
* 영어 및 한국어 콘텐츠의 올바른 URL 매핑 설정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->