### PR TITLE
Fix: 미들웨어 리다이렉트 시 쿼리 파라미터 보존 및 trailing slash 처리

### DIFF
--- a/app/[locale]/default.tsx
+++ b/app/[locale]/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,21 +10,30 @@ export default async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
   const permanentRedirect = { status: 301 as const };
 
+  // searchParams 보존하며 리다이렉트하는 헬퍼
+  const redirectTo = (newPath: string) => {
+    const url = request.nextUrl.clone();
+    url.pathname = newPath;
+    return NextResponse.redirect(url, permanentRedirect);
+  };
+
+  // trailing slash 정규화 (예: /en/ → /en)
+  if (pathname !== "/" && pathname.endsWith("/")) {
+    return redirectTo(pathname.slice(0, -1));
+  }
+
   // 기존 /home, /ko/home, /en/home URL → 루트로 301 영구 리다이렉트 (이전 URL 호환)
   if (pathname === "/home" || pathname === `/${LOCALE_KO}/home`) {
-    return NextResponse.redirect(new URL("/", request.url), permanentRedirect);
+    return redirectTo("/");
   }
   if (pathname === `/${LOCALE_EN}/home`) {
-    return NextResponse.redirect(
-      new URL(`/${LOCALE_EN}`, request.url),
-      permanentRedirect,
-    );
+    return redirectTo(`/${LOCALE_EN}`);
   }
 
   // 유효한 경로만 허용, 나머지는 루트로 리다이렉트
   const validPaths = ["/", `/${LOCALE_EN}`];
   if (!validPaths.includes(pathname)) {
-    return NextResponse.redirect(new URL("/", request.url), permanentRedirect);
+    return redirectTo("/");
   }
 
   // 나머지는 next-intl middleware에게 위임


### PR DESCRIPTION
- searchParams 유실 방지 (예: ?theme=dark 보존)
- trailing slash 정규화 (예: /en/ → /en)
- App Router 병렬 라우트용 default.tsx 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 내부 페이지 모듈 추가 (사용자 인터페이스 변경 없음)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->