### PR TITLE
Feat: 질문 선택 시 해당 질문 스크롤 상단으로 자동 이동 되도록 처리

### DIFF
--- a/app/[locale]/@chat/body.tsx
+++ b/app/[locale]/@chat/body.tsx
@@ -21,6 +21,12 @@ export default function ChatBody() {
   /* 새로 고침 여부를 ref로 관리 */
   const isRefresh = useRef(true);
 
+  /* 스크롤 컨테이너 및 방금 선택한 질문 말풍선 ref */
+  const containerRef = useRef<HTMLDivElement>(null);
+  const lastQuestionRef = useRef<HTMLDivElement>(null);
+  /* 이전 질문 개수 추적 (초기 null = 최초 마운트/새로고침 복원) */
+  const prevQuestionCountRef = useRef<number | null>(null);
+
   useEffect(() => {
     setTimeout(() => {
       isRefresh.current = false;
@@ -31,21 +37,75 @@ export default function ChatBody() {
     .filter((chat) => chat.type === CHAT_TYPE_QUESTION)
     .map((chat) => chat.id);
 
+  /* 질문 개수 (답변 push로는 변하지 않아 질문 1개당 스크롤 1회만 트리거) */
+  const questionCount = shownQuestionIds.length;
+  /* 배열에 append만 되므로 마지막 질문 = 방금 선택한 질문 */
+  const lastQuestionId = shownQuestionIds[shownQuestionIds.length - 1];
+
+  /* 방금 선택한 질문을 스크롤 영역 최상단으로 올림 (ChatGPT식) */
+  const scrollToLastQuestion = () => {
+    requestAnimationFrame(() => {
+      const container = containerRef.current;
+      const target = lastQuestionRef.current;
+      if (!container || !target) return;
+
+      /* 컨테이너 기준 타깃 위치 = (타깃 top - 컨테이너 top) + 현재 scrollTop, 상단 소폭 여백 8px */
+      const top = Math.max(
+        0,
+        target.getBoundingClientRect().top -
+          container.getBoundingClientRect().top +
+          container.scrollTop -
+          8
+      );
+
+      const prefersReducedMotion = window.matchMedia(
+        "(prefers-reduced-motion: reduce)"
+      ).matches;
+
+      /* scrollIntoView는 window까지 번질 수 있어 컨테이너만 직접 스크롤 */
+      container.scrollTo({
+        top,
+        behavior: prefersReducedMotion ? "auto" : "smooth",
+      });
+    });
+  };
+
+  useEffect(() => {
+    /* 최초 마운트(새로고침 복원)는 카운트만 기록하고 스크롤하지 않음 */
+    if (prevQuestionCountRef.current === null) {
+      prevQuestionCountRef.current = questionCount;
+      return;
+    }
+    /* 질문이 늘어난 경우(=사용자가 새로 선택)에만 스크롤 */
+    if (questionCount > prevQuestionCountRef.current) {
+      scrollToLastQuestion();
+    }
+    prevQuestionCountRef.current = questionCount;
+  }, [questionCount]);
+
   return (
     <div
+      ref={containerRef}
       className={`relative h-full px-5 pt-6 pb-20 max-h-dvh flex flex-col gap-4 overflow-y-auto`}
     >
       {chatHistory.map((chat) => {
         /* 질문 */
         if (chat.type === CHAT_TYPE_QUESTION) {
-          return (
+          const questionEl = (
             <Question
-              key={`QUESTION${chat.id}`}
               locale={locale}
               chat={chat as QuestionType}
               /* 999는 고정 인삿말 이기 때문에 마크를 비노출 */
               showMark={chat.id !== 999}
             />
+          );
+          /* 마지막(방금 선택한) 질문만 스크롤 타깃 ref용 래퍼로 감쌈 */
+          return chat.id === lastQuestionId ? (
+            <div key={`QUESTION${chat.id}`} ref={lastQuestionRef}>
+              {questionEl}
+            </div>
+          ) : (
+            <div key={`QUESTION${chat.id}`}>{questionEl}</div>
           );
         }
         /* 답변 */

--- a/app/globals.css
+++ b/app/globals.css
@@ -154,6 +154,15 @@ body {
   }
 }
 
+/* 동작 줄이기 선호 시 채팅 진입 애니메이션 감축 (자동 스크롤 behavior 분기와 일관) */
+@media (prefers-reduced-motion: reduce) {
+  .questionButtonBox,
+  .answerLoader,
+  .answer {
+    animation: none;
+  }
+}
+
 /* 질문 CSS */
 .questionWrapper {
   @apply w-11/12 flex flex-col gap-3 web:w-4/5;


### PR DESCRIPTION
모바일/데스크탑 모두 질문 선택 후 답변이 화면 밖 위쪽에 생겨 수동 스크롤이 필요하던 문제 해결 선택한 질문 말풍선을 스크롤 컨테이너 최상단으로 올려 질문→답변→남은 리스트 순으로 노출

- questionCount 증가 시에만 스크롤해 답변 다중 push 및 새로고침 복원 시 오동작 방지
- scrollIntoView 대신 container.scrollTo로 window 스크롤 번짐 차단
- prefers-reduced-motion 시 즉시 스크롤 및 진입 애니메이션 감축

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 새 질문이 추가되면 자동으로 마지막 질문 위치로 스크롤되도록 개선했습니다.
  * 사용자의 모션 설정에 맞춰 부드러운 스크롤 또는 즉시 이동으로 동작합니다.

* **버그 수정**
  * 질문 목록이 바뀌지 않았을 때는 불필요한 자동 스크롤이 발생하지 않도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->